### PR TITLE
Non breaking space for interpunction

### DIFF
--- a/src/app/iconize.pipe.ts
+++ b/src/app/iconize.pipe.ts
@@ -5,6 +5,10 @@ import { Pipe, PipeTransform } from '@angular/core'
 })
 export class IconizePipe implements PipeTransform {
 
+  private static readonly NON_SEPARATION_SPECIAL_CHARACTERS = ['\\.', ',', ';', '\\-', '\\)']
+
+  static nonSeparationSpecialCharactersRegex: string = IconizePipe.NON_SEPARATION_SPECIAL_CHARACTERS.join('|');
+
   private readonly BASE_HTML_STRING = `
   <picture class="icon-picture">
     <source type="image/webp" srcset="assets/icons/png/$1.webp">
@@ -12,6 +16,7 @@ export class IconizePipe implements PipeTransform {
     <img class="icon-image" src="assets/icons/png/$1.png" alt="$1" aria-hidden="false" aria-label="$1 icon">
   </picture>
   `
+  private readonly NOBR_HTML_STRING = `<span class="nobr">` + this.BASE_HTML_STRING + `$2` + `</span>`
 
   private readonly DARK_MAP = {
     'seed': 'seed-dark'
@@ -32,7 +37,9 @@ export class IconizePipe implements PipeTransform {
   }
 
   transform(value: string, dark = false, glow = false): string {
-    let result = value && value.replace(/\[([a-z\-]+)\]/g, this.BASE_HTML_STRING)
+    let result = value && value
+      .replace(new RegExp('\\[([a-z\\-]+)\\]' + '(?!' + IconizePipe.nonSeparationSpecialCharactersRegex + ')', 'g'), this.BASE_HTML_STRING)
+      .replace(new RegExp('\\[([a-z\\-]+)\\]' + '(' + IconizePipe.nonSeparationSpecialCharactersRegex + ')', 'g'), this.NOBR_HTML_STRING)
 
     if (dark)
       Object.entries(this.DARK_MAP).forEach(([key, value]) =>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -150,6 +150,10 @@ body {
     max-width: 1em;
 }
 
+.nobr {
+  white-space: nowrap;
+}
+
 .card-detail-panel {
         .mat-dialog-container {
         background-color: unset;


### PR DESCRIPTION
Displaying interpunction characters not on start of line when preceded by picture.
Before 
![obraz](https://user-images.githubusercontent.com/11087559/198880507-ead858bf-522f-44b4-b168-238b015b10c3.png)
After 
![obraz](https://user-images.githubusercontent.com/11087559/198880525-60715cc0-abd8-41e1-a4b9-aa099dd15b8a.png)
Fixes #29 